### PR TITLE
fix: contact link i18n

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -18,6 +18,6 @@ Depending on the needs of the organization requesting assistance, KyberVPK can h
 
 **How do I get help:**
 
-* [Contact us](/contact/).
+* [Contact us]({{< ref "/contact" >}}).
 * We evaluate each case individually and confidentially.
 * The help we provide does not cost you or your business anything.

--- a/content/fi/_index.md
+++ b/content/fi/_index.md
@@ -18,6 +18,6 @@ Apua pyyt채v채n organisaation tarpeista riippuen KyberVPK voi auttaa ennaltaehk�
 
 **Kuinka saan apua:**
 
-* [Ota yhteytt채](/contact/).
+* [Ota yhteytt채]({{< ref "/contact" >}}).
 * Arvioimme jokaisen tapauksen yksitellen ja luottamuksella.
 * Tarjoamamme apu ei maksa sinulle tai yrityksellesi mit채채n.

--- a/content/sv/_index.md
+++ b/content/sv/_index.md
@@ -18,6 +18,6 @@ Beroende på behoven hos den organisation som begär hjälp, kan KyberVPK hjälp
 
 **Hur får jag hjälp:**
 
-* [Kontakta oss](/contact/).
+* [Kontakta oss]({{< ref "/contact" >}}).
 * Vi utvärderar varje fall individuellt och konfidentiellt.
 * Hjälpen vi ger kostar inte dig eller ditt företag någonting.


### PR DESCRIPTION
i18n requires proper `ref` usage in Markdown. We didn't have that. Now we do.